### PR TITLE
Implement segment lookup interface & logic inside lsmtree

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -16,4 +16,5 @@ target_link_libraries(
 	DB
   LSMTree
   MemTable
-	Config)
+	Config
+	HashIndex)

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -11,13 +11,25 @@
  */
 int main(int argc, char *argv[]) {
   // TODO(lnikon): This is temp arg handling. Refactor.
-  if (argc != 2) {
-    spdlog::error("Usage: tkvp <path-to-db>");
-    return 1;
-  }
+  // if (argc != 2) {
+  //   spdlog::error("Usage: tkvp <path-to-db>");
+  //   return 1;
+  // }
 
   auto pConfig = config::make_shared();
+  pConfig->LSMTreeConfig.DiskFlushThresholdSize = 10;
   db::db_t db(pConfig);
+
+  db.put(db::lsmtree::key_t{"aaaaaa"}, db::lsmtree::value_t{"version1"});
+  db.put(db::lsmtree::key_t{"aaaaaa"}, db::lsmtree::value_t{"version2"});
+  db.put(db::lsmtree::key_t{"aaaaaa"}, db::lsmtree::value_t{"version3"});
+  db.put(db::lsmtree::key_t{"cccccc"}, db::lsmtree::value_t{"dddddd"});
+
+  auto recordOpt{db.get(db::lsmtree::key_t{"aaaaaa"})};
+  if (recordOpt) {
+    const auto record{recordOpt.value()};
+    spdlog::info("key={}", record.m_key.m_key);
+  }
 
   return 0;
 }

--- a/lib/config/config.h
+++ b/lib/config/config.h
@@ -2,14 +2,16 @@
 
 #include <db/db_config.h>
 #include <structures/lsmtree/lsmtree_config.h>
+#include <structures/lsmtree/segments/segment_config.h>
 
 namespace config {
 
 struct config_t {
   db::db_config_t DatabaseConfig;
   structures::lsmtree::lsmtree_config_t LSMTreeConfig;
+  structures::lsmtree::segments::segment_config_t SegmentConfig;
 
-	[[nodiscard]] std::filesystem::path get_segments_path() const;
+  [[nodiscard]] std::filesystem::path get_segments_path() const;
 };
 
 using sptr_t = std::shared_ptr<config_t>;

--- a/lib/db/CMakeLists.txt
+++ b/lib/db/CMakeLists.txt
@@ -19,4 +19,5 @@ target_link_libraries(
   LSMTree
   MemTable
   DB
-	Config)
+	Config
+	HashIndex)

--- a/lib/db/CMakeLists.txt
+++ b/lib/db/CMakeLists.txt
@@ -12,7 +12,6 @@ target_link_libraries(
   DBTest
   boost::boost
   Catch2::Catch2
-  gRPC::grpc
   spdlog::spdlog
   fmt::fmt
   ZLIB::ZLIB

--- a/lib/db/db.cpp
+++ b/lib/db/db.cpp
@@ -6,7 +6,10 @@ namespace db {
  * TODO(lnikon): Move @dbPath and @lsmTreeConfig into DBConfig
  */
 db_t::db_t(const config::sptr_t config)
-    : m_config{config}, m_pSegmentManager{segment_manager::make_shared(config)},
+    : m_config{config},
+      m_pSegmentStorage{lsmtree::segment_storage::make_shared()},
+      m_pSegmentManager{
+          segment_manager::make_shared(config, m_pSegmentStorage)},
       m_lsmTree{config, m_pSegmentManager} {}
 
 bool db_t::open() {

--- a/lib/db/db.h
+++ b/lib/db/db.h
@@ -4,8 +4,6 @@
 #include <db/db_config.h>
 #include <structures/lsmtree/lsmtree.h>
 
-#include <filesystem>
-
 namespace db {
 
 using namespace structures::lsmtree;
@@ -20,6 +18,7 @@ using namespace structures::lsmtree;
 
 class db_t {
 public:
+  using segstorage_sptr_t = lsmtree::segment_storage::sptr;
   using segmgr_sptr_t = segment_manager::lsmtree_segment_manager_shared_ptr_t;
   using lsmtree_config_t = structures::lsmtree::lsmtree_config_t;
   using lsmtree_t = structures::lsmtree::lsmtree_t;
@@ -40,6 +39,7 @@ private:
 
 private:
   const config::sptr_t m_config;
+  segstorage_sptr_t m_pSegmentStorage;
   segmgr_sptr_t m_pSegmentManager;
   lsmtree_t m_lsmTree;
 };

--- a/lib/db/db_test.cpp
+++ b/lib/db/db_test.cpp
@@ -7,10 +7,9 @@
 
 TEST_CASE("db interface validation", "[db]") {
   config::sptr_t pConfig{config::make_shared()};
-  auto pSegmentManager =
-      std::make_shared<structures::lsmtree::lsmtree_segment_manager_t>(pConfig);
-
-  structures::lsmtree::lsmtree_t lsmTree(pConfig, pSegmentManager);
+	auto pSegmentStorage {db::lsmtree::segment_storage::make_shared()};
+  auto pSegmentManager {db::lsmtree::segment_manager::make_shared(pConfig, pSegmentStorage)};
+  auto lsmTree {structures::lsmtree::lsmtree_t{pConfig, pSegmentManager}};
 
   SECTION("fail when db path is empty") {
     db::db_t db(pConfig);

--- a/lib/structures/CMakeLists.txt
+++ b/lib/structures/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.18)
 project(zkv)
 
+add_subdirectory(hashindex)
 add_subdirectory(lsmtree)
 add_subdirectory(memtable)
 add_subdirectory(sorted_vector)

--- a/lib/structures/hashindex/CMakeLists.txt
+++ b/lib/structures/hashindex/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.27)
+project(zkv)
+
+add_library(
+	HashIndex
+  "hashindex.cpp")
+
+set_target_properties(HashIndex PROPERTIES CXX_STANDARD 23)
+target_include_directories(HashIndex INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+
+# add_executable(HashIndexTest "hashindex_test.cpp")
+# set_target_properties(HashIndexTest PROPERTIES CXX_STANDARD 23)
+# target_link_libraries(
+#   HashIndexTest
+#   boost::boost
+#   Catch2::Catch2
+#   gRPC::grpc
+#   spdlog::spdlog
+#   fmt::fmt
+#   ZLIB::ZLIB
+# 	LSMTree
+#   HashIndex
+#   MemTable
+# 	Config)

--- a/lib/structures/hashindex/hashindex.cpp
+++ b/lib/structures/hashindex/hashindex.cpp
@@ -9,4 +9,12 @@ void hashindex_t::emplace(structures::lsmtree::key_t key) {
   m_cursor += key.size();
 }
 
+bool hashindex_t::empty() const { return m_offsets.empty(); }
+
+std::optional<hashindex_t::offset_t>
+hashindex_t::get_offset(const structures::lsmtree::key_t &key) const {
+  const auto it{m_offsets.find(key)};
+  return it == m_offsets.end() ? std::nullopt : std::make_optional(it->second);
+}
+
 } // namespace structures::hashindex

--- a/lib/structures/hashindex/hashindex.cpp
+++ b/lib/structures/hashindex/hashindex.cpp
@@ -1,0 +1,12 @@
+#include <structures/hashindex/hashindex.h>
+
+namespace structures::hashindex {
+
+hashindex_t::hashindex_t() : m_cursor{0} {}
+
+void hashindex_t::emplace(structures::lsmtree::key_t key) {
+  m_offsets.emplace(key, m_cursor);
+  m_cursor += key.size();
+}
+
+} // namespace structures::hashindex

--- a/lib/structures/hashindex/hashindex.h
+++ b/lib/structures/hashindex/hashindex.h
@@ -22,6 +22,11 @@ public:
 
   void emplace(structures::lsmtree::key_t key);
 
+  bool empty() const;
+
+  [[nodiscard]] std::optional<offset_t>
+  get_offset(const structures::lsmtree::key_t &key) const;
+
 private:
   cursor_t m_cursor;
   std::unordered_map<structures::lsmtree::key_t, offset_t> m_offsets;

--- a/lib/structures/hashindex/hashindex.h
+++ b/lib/structures/hashindex/hashindex.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstdint>       // std::uint64_t
+#include <unordered_map> // std::unordered_map
+
+#include <structures/lsmtree/lsmtree_types.h>
+
+namespace structures::hashindex {
+
+// TODO(lnikon): Benchmarks with flat_*maps to understand the
+// performance.
+class hashindex_t {
+public:
+  using offset_t = std::uint64_t;
+  using cursor_t = std::uint64_t;
+
+  hashindex_t();
+  hashindex_t(const hashindex_t &) = default;
+  hashindex_t(hashindex_t &&) = default;
+  hashindex_t &operator=(const hashindex_t &) = default;
+  hashindex_t &operator=(hashindex_t &&) = default;
+
+  void emplace(structures::lsmtree::key_t key);
+
+private:
+  cursor_t m_cursor;
+  std::unordered_map<structures::lsmtree::key_t, offset_t> m_offsets;
+};
+
+} // namespace structures::hashindex

--- a/lib/structures/lsmtree/CMakeLists.txt
+++ b/lib/structures/lsmtree/CMakeLists.txt
@@ -26,4 +26,5 @@ target_link_libraries(
   ZLIB::ZLIB
   LSMTree
   MemTable
-	Config)
+	Config
+	HashIndex)

--- a/lib/structures/lsmtree/lsmtree.cpp
+++ b/lib/structures/lsmtree/lsmtree.cpp
@@ -49,7 +49,20 @@ std::optional<record_t>
 structures::lsmtree::lsmtree_t::get(const key_t &key) const {
   // TODO(lnikon): Use Index and on-disk segments.
   // For now we'll just lookup in-memory memtable.
-  return m_table->find(key);
+  auto result{m_table->find(key)};
+  if (result) {
+    return result;
+  } else {
+    const auto segments = m_pSegmentsMgr->get_segments();
+    for (const auto &segment : *segments) {
+      result = segment->get_record(key);
+      if (result.has_value()) {
+        return result;
+      }
+    }
+  }
+
+  return std::nullopt;
 }
 
 } // namespace structures::lsmtree

--- a/lib/structures/lsmtree/lsmtree.cpp
+++ b/lib/structures/lsmtree/lsmtree.cpp
@@ -28,18 +28,21 @@ void lsmtree_t::put(const structures::lsmtree::key_t &key,
   // TODO(lnikon): Is it possible to use better locking strategy?
   // TODO(lnikon): Compactation can be a periodic job?
   if (std::unique_lock ul(m_mutex);
-      key.size() + valueSizeOpt.value() + m_table->size() >=
-      m_config->LSMTreeConfig.DiskFlushThresholdSize) {
+      m_table->size() && key.size() + valueSizeOpt.value() + m_table->size() >=
+                             m_config->LSMTreeConfig.DiskFlushThresholdSize) {
     spdlog::debug("flushing table. m_table->size()={}", m_table->size());
 
     // TODO(lnikon): For the future, keep LSMTree readable while dumping.
     // This can be achieved by moving the current copy into the new async task
     // to dump and creating a new copy.
-    m_pSegmentsMgr
-        ->get_new_segment(m_config->LSMTreeConfig.SegmentType,
-                          std::move(m_table))
-        ->flush();
+    auto pSegment = m_pSegmentsMgr->get_new_segment(
+        m_config->LSMTreeConfig.SegmentType, std::move(m_table));
+
+    // TODO(lnikon): Somehow signal via some cv that it's safe to use the new
+    // memtable
     m_table = memtable::make_unique();
+    pSegment->flush();
+    m_pSegmentsMgr->get_segments()->put(pSegment);
   }
 
   m_table->emplace(record_t{key, value});

--- a/lib/structures/lsmtree/lsmtree.h
+++ b/lib/structures/lsmtree/lsmtree.h
@@ -6,7 +6,6 @@
 #define CPP_PROJECT_TEMPLATE_LSMTREE_H
 
 #include <optional>
-#include <thread>
 
 #include <structures/lsmtree/lsmtree_config.h>
 #include <structures/lsmtree/lsmtree_types.h>

--- a/lib/structures/lsmtree/lsmtree_test.cpp
+++ b/lib/structures/lsmtree/lsmtree_test.cpp
@@ -4,7 +4,6 @@
 #include <structures/lsmtree/lsmtree.h>
 #include <structures/lsmtree/lsmtree_config.h>
 #include <structures/lsmtree/lsmtree_types.h>
-
 #include <filesystem>
 #include <limits>
 #include <random>
@@ -75,13 +74,14 @@ TEST_CASE("Flush regular segment", std::string(componentName)) {
   auto randomKeys = generateRandomStringPairVector(1024);
 
   SECTION("Put and Get") {
-    config::sptr_t pConfig{config::make_shared()};
+    auto pConfig{config::make_shared()};
     pConfig->LSMTreeConfig.SegmentType =
         lsmtree::lsmtree_segment_type_t::mock_k;
+    auto pStorage{lsmtree::segment_storage::make_shared()};
 
     auto pSegmentManager =
         std::make_shared<structures::lsmtree::lsmtree_segment_manager_t>(
-            pConfig);
+            pConfig, pStorage);
 
     lsmtree::lsmtree_t lsmt(pConfig, pSegmentManager);
     for (const auto &kv : randomKeys) {
@@ -101,10 +101,11 @@ TEST_CASE("Flush regular segment", std::string(componentName)) {
     pConfig->LSMTreeConfig.DiskFlushThresholdSize = 2048;
     pConfig->LSMTreeConfig.SegmentType =
         lsmtree::lsmtree_segment_type_t::regular_k;
+    auto pStorage{lsmtree::segment_storage::make_shared()};
 
     auto pSegmentManager =
         std::make_shared<structures::lsmtree::lsmtree_segment_manager_t>(
-            pConfig);
+            pConfig, pStorage);
 
     lsmtree::lsmtree_t lsmt(pConfig, pSegmentManager);
     for (const auto &kv : randomKeys) {

--- a/lib/structures/lsmtree/lsmtree_types.h
+++ b/lib/structures/lsmtree/lsmtree_types.h
@@ -5,10 +5,6 @@
 #ifndef ZKV_LSMTREETYPES_H
 #define ZKV_LSMTREETYPES_H
 
-#include <cstddef>
-#include <memory>
-#include <string>
-
 #include <structures/memtable/memtable.h>
 
 namespace structures::lsmtree {

--- a/lib/structures/lsmtree/segments/interface_lsmtree_segment.cpp
+++ b/lib/structures/lsmtree/segments/interface_lsmtree_segment.cpp
@@ -13,11 +13,11 @@ interface_lsmtree_segment_t::interface_lsmtree_segment_t(
     std::filesystem::path path, memtable_unique_ptr_t pMemtable)
     : m_pMemtable(std::move(pMemtable)), m_path(std::move(path)) {}
 
-std::string interface_lsmtree_segment_t::get_name() const {
+interface_lsmtree_segment_t::name_t interface_lsmtree_segment_t::get_name() const {
   return m_path.stem().string();
 }
 
-std::filesystem::path interface_lsmtree_segment_t::get_path() const {
+interface_lsmtree_segment_t::path_t interface_lsmtree_segment_t::get_path() const {
   return m_path;
 }
 

--- a/lib/structures/lsmtree/segments/interface_lsmtree_segment.h
+++ b/lib/structures/lsmtree/segments/interface_lsmtree_segment.h
@@ -5,6 +5,7 @@
 #ifndef ZKV_INTERFACE_LSMTREE_SEGMENT_H
 #define ZKV_INTERFACE_LSMTREE_SEGMENT_H
 
+#include <structures/hashindex/hashindex.h>
 #include <structures/lsmtree/lsmtree_types.h>
 
 #include <filesystem>
@@ -15,6 +16,9 @@ namespace structures::lsmtree {
 
 class interface_lsmtree_segment_t {
 public:
+  using name_t = std::string;
+  using path_t = std::filesystem::path;
+
   explicit interface_lsmtree_segment_t(std::filesystem::path path,
                                        memtable_unique_ptr_t pMemtable);
 
@@ -28,8 +32,11 @@ public:
 
   virtual ~interface_lsmtree_segment_t() = default;
 
-  [[nodiscard]] std::string get_name() const;
-  [[nodiscard]] std::filesystem::path get_path() const;
+  [[nodiscard]] name_t get_name() const;
+  [[nodiscard]] path_t get_path() const;
+
+  [[nodiscard]] virtual std::optional<lsmtree::record_t> 
+  get_record(const lsmtree::key_t &key) = 0;
 
   virtual void flush() = 0;
 

--- a/lib/structures/lsmtree/segments/interface_lsmtree_segment.h
+++ b/lib/structures/lsmtree/segments/interface_lsmtree_segment.h
@@ -14,6 +14,11 @@
 
 namespace structures::lsmtree {
 
+enum class SegmentMode {
+	Read,
+	Write,
+};
+
 class interface_lsmtree_segment_t {
 public:
   using name_t = std::string;

--- a/lib/structures/lsmtree/segments/lsmtree_mock_segment.cpp
+++ b/lib/structures/lsmtree/segments/lsmtree_mock_segment.cpp
@@ -15,6 +15,11 @@ lsmtree_mock_segment_t::lsmtree_mock_segment_t(std::filesystem::path path,
                                                memtable_unique_ptr_t pMemtable)
     : interface_lsmtree_segment_t(std::move(path), std::move(pMemtable)) {}
 
+[[nodiscard]] std::optional<lsmtree::record_t>
+lsmtree_mock_segment_t::get_record(const lsmtree::key_t &) {
+  return std::nullopt;
+}
+
 void lsmtree_mock_segment_t::flush() {
   assert(m_pMemtable);
   spdlog::info("(lsmtree_mock_segment_t): This is an mock implementation of "

--- a/lib/structures/lsmtree/segments/lsmtree_mock_segment.h
+++ b/lib/structures/lsmtree/segments/lsmtree_mock_segment.h
@@ -15,6 +15,8 @@ class lsmtree_mock_segment_t : public interface_lsmtree_segment_t {
 public:
   lsmtree_mock_segment_t(std::filesystem::path path, memtable_unique_ptr_t pMemtable);
 
+  [[nodiscard]] std::optional<lsmtree::record_t> get_record(const lsmtree::key_t &key) override;
+
   void flush() override;
 };
 

--- a/lib/structures/lsmtree/segments/lsmtree_regular_segment.cpp
+++ b/lib/structures/lsmtree/segments/lsmtree_regular_segment.cpp
@@ -2,12 +2,20 @@
 // Created by nikon on 2/6/22.
 //
 
+#include "structures/lsmtree/lsmtree_types.h"
+#include <optional>
 #define FMT_HEADER_ONLY
 #include <spdlog/spdlog.h>
 
 #include <cassert>
+#include <fstream>
 
 #include <structures/lsmtree/segments/lsmtree_regular_segment.h>
+
+// WriteableSegment -> get_record
+// ReadableSegment -> flush
+// or:
+// enum SegmentMode { Read, Write, Read | Write }
 
 namespace structures::lsmtree {
 
@@ -16,15 +24,50 @@ lsmtree_regular_segment_t::lsmtree_regular_segment_t(
     : interface_lsmtree_segment_t(std::move(path), std::move(pMemtable)) {}
 
 [[nodiscard]] std::optional<lsmtree::record_t>
-lsmtree_regular_segment_t::get_record(const lsmtree::key_t &) {
+lsmtree_regular_segment_t::get_record(const lsmtree::key_t &key) {
+  // TODO(lnikon): Check `prepopulate_segment_index`. If set, skip building the
+  // index.
+
+  assert(!m_hashIndex.empty());
+
+  const auto offset{m_hashIndex.get_offset(key)};
+  if (offset) {
+    // TODO(lnikon): Consider memory mapping
+    std::fstream segmentStream{get_path(), std::ios::in};
+    segmentStream.seekg(offset.value());
+    // TODO(lnikon): Check that offset isn't greater than the stream
+    std::size_t keySz{0};
+    lsmtree::record_t::key_t::storage_type_t key;
+    std::size_t valueSz{0};
+    std::string valueStr;
+    lsmtree::record_t::value_t::underlying_value_type_t value;
+
+    segmentStream >> keySz;
+    segmentStream >> key;
+    segmentStream >> valueSz;
+    segmentStream >> valueStr;
+    value = valueStr;
+
+    spdlog::info("keySz={} key={} valueSz={} valueStr={}", keySz, key, valueSz,
+                  valueStr);
+
+    return std::make_optional(
+        record_t{key_t{std::move(key)}, value_t{std::move(value)}});
+  }
+
   return std::nullopt;
 }
 
 void lsmtree_regular_segment_t::flush() {
-  assert(m_pMemtable);
+  // If m_pMemtable is null, then segment has been flushed
+  if (!m_pMemtable) {
+    return;
+  }
+
   std::stringstream ss;
   for (const auto &kv : *m_pMemtable) {
     ss << kv;
+    m_hashIndex.emplace(kv.m_key);
   }
 
   // TODO(vahag): Use fadvise() and O_DIRECT
@@ -42,6 +85,8 @@ void lsmtree_regular_segment_t::flush() {
   stream << ss.str();
   stream.flush();
   stream.close();
+
+  // TODO(lnikon): On successfull flush purge the old delete memtable
 }
 
 } // namespace structures::lsmtree

--- a/lib/structures/lsmtree/segments/lsmtree_regular_segment.cpp
+++ b/lib/structures/lsmtree/segments/lsmtree_regular_segment.cpp
@@ -15,6 +15,11 @@ lsmtree_regular_segment_t::lsmtree_regular_segment_t(
     std::filesystem::path path, memtable_unique_ptr_t pMemtable)
     : interface_lsmtree_segment_t(std::move(path), std::move(pMemtable)) {}
 
+[[nodiscard]] std::optional<lsmtree::record_t>
+lsmtree_regular_segment_t::get_record(const lsmtree::key_t &) {
+  return std::nullopt;
+}
+
 void lsmtree_regular_segment_t::flush() {
   assert(m_pMemtable);
   std::stringstream ss;

--- a/lib/structures/lsmtree/segments/lsmtree_regular_segment.h
+++ b/lib/structures/lsmtree/segments/lsmtree_regular_segment.h
@@ -18,6 +18,9 @@ public:
   get_record(const lsmtree::key_t &key) override;
 
   void flush() override;
+
+private:
+	hashindex::hashindex_t m_hashIndex;
 };
 
 } // namespace structures::lsmtree

--- a/lib/structures/lsmtree/segments/lsmtree_regular_segment.h
+++ b/lib/structures/lsmtree/segments/lsmtree_regular_segment.h
@@ -14,6 +14,9 @@ public:
   explicit lsmtree_regular_segment_t(std::filesystem::path path,
                                      memtable_unique_ptr_t pMemtable);
 
+  [[nodiscard]] std::optional<lsmtree::record_t>
+  get_record(const lsmtree::key_t &key) override;
+
   void flush() override;
 };
 

--- a/lib/structures/lsmtree/segments/lsmtree_segment_manager.cpp
+++ b/lib/structures/lsmtree/segments/lsmtree_segment_manager.cpp
@@ -18,10 +18,7 @@ segment_shared_ptr_t lsmtree_segment_manager_t::get_new_segment(
     const structures::lsmtree::lsmtree_segment_type_t type,
     memtable_unique_ptr_t pMemtable) {
   const auto path{construct_path(get_next_name())};
-
-  auto result = lsmtree_segment_factory(type, path, std::move(pMemtable));
-  m_pStorage->put(result);
-  return result;
+  return lsmtree_segment_factory(type, path, std::move(pMemtable));
 }
 
 segment_shared_ptr_t

--- a/lib/structures/lsmtree/segments/lsmtree_segment_manager.cpp
+++ b/lib/structures/lsmtree/segments/lsmtree_segment_manager.cpp
@@ -9,8 +9,8 @@
 namespace structures::lsmtree::segment_manager {
 
 lsmtree_segment_manager_t::lsmtree_segment_manager_t(
-    const config::sptr_t &config)
-    : m_config{config} {
+    const config::sptr_t &config, lsmtree::segment_storage::sptr pStorage)
+    : m_config{config}, m_pStorage{pStorage} {
   assert(!m_config->LSMTreeConfig.SegmentsDirectoryName.empty());
 }
 
@@ -20,29 +20,25 @@ segment_shared_ptr_t lsmtree_segment_manager_t::get_new_segment(
   const auto path{construct_path(get_next_name())};
 
   auto result = lsmtree_segment_factory(type, path, std::move(pMemtable));
-  m_segments[result->get_name()] = result;
+  m_pStorage->put(result);
   return result;
 }
 
 segment_shared_ptr_t
 lsmtree_segment_manager_t::get_segment(const std::string &name) {
-  assert(!name.empty());
-  segment_shared_ptr_t result{nullptr};
-  if (auto it = m_segments.find(name); it != m_segments.end()) {
-    result = it->second;
-  } else {
-    spdlog::warn("unable to find lsm tree segment with name {:s}", name);
-  }
+  return m_pStorage->get(name);
+}
 
-  return result;
+lsmtree::segment_storage::sptr lsmtree_segment_manager_t::get_segments() {
+  return m_pStorage->shared_from_this();
 }
 
 std::vector<lsmtree_segment_manager_t::segment_name_t>
 lsmtree_segment_manager_t::get_segment_names() const {
   std::vector<segment_name_t> result;
-  result.reserve(m_segments.size());
-  for (const auto &[name, _] : m_segments) {
-    result.emplace_back(name);
+  result.reserve(m_pStorage->size());
+  for (const auto &segment : *m_pStorage) {
+    result.emplace_back(segment->get_name());
   }
   return result;
 }

--- a/lib/structures/lsmtree/segments/lsmtree_segment_manager.h
+++ b/lib/structures/lsmtree/segments/lsmtree_segment_manager.h
@@ -4,13 +4,14 @@
 
 #pragma once
 
+#include <filesystem>
+#include <unordered_map>
+
 #include <config/config.h>
 #include <structures/lsmtree/lsmtree_config.h>
 #include <structures/lsmtree/lsmtree_types.h>
 #include <structures/lsmtree/segments/interface_lsmtree_segment.h>
-
-#include <filesystem>
-#include <unordered_map>
+#include <structures/lsmtree/segments/lsmtree_segment_storage.h>
 
 namespace structures::lsmtree::segment_manager {
 /**
@@ -23,27 +24,29 @@ public:
   using segment_map_t =
       std::unordered_map<segment_name_t, segment_shared_ptr_t>;
 
-  explicit lsmtree_segment_manager_t(const config::sptr_t &config);
+  explicit lsmtree_segment_manager_t(const config::sptr_t &config,
+                                     lsmtree::segment_storage::sptr pStorage);
 
   // TODO(lnikon): Should be thread-safe?
   segment_shared_ptr_t get_new_segment(const lsmtree_segment_type_t type,
                                        memtable_unique_ptr_t pMemtable);
 
   segment_shared_ptr_t get_segment(const segment_name_t &name);
+  lsmtree::segment_storage::sptr get_segments();
 
   std::vector<segment_name_t> get_segment_names() const;
   std::vector<std::filesystem::path> get_segment_paths() const;
 
   // TODO: Start merging on-disk segments.
-  // void Compact();
+  // void compact();
 private:
   std::string get_next_name();
   std::filesystem::path construct_path(const std::string &name) const;
 
 private:
-	config::sptr_t m_config;
+  config::sptr_t m_config;
   uint64_t m_index{0};
-  segment_map_t m_segments;
+  segment_storage::sptr m_pStorage;
 };
 
 using lsmtree_segment_manager_shared_ptr_t =
@@ -52,7 +55,7 @@ using lsmtree_segment_manager_shared_ptr_t =
 template <typename... Args>
 lsmtree_segment_manager_shared_ptr_t make_shared(Args... args) {
   return std::make_shared<lsmtree_segment_manager_t>(
-      std::forward<Args...>(args)...);
+      std::forward<Args>(args)...);
 }
 
 } // namespace structures::lsmtree::segment_manager

--- a/lib/structures/lsmtree/segments/lsmtree_segment_storage.cpp
+++ b/lib/structures/lsmtree/segments/lsmtree_segment_storage.cpp
@@ -2,20 +2,41 @@
 
 #include <structures/lsmtree/segments/lsmtree_segment_storage.h>
 
-namespace structures::lsmtree {
+namespace structures::lsmtree::segment_storage {
 
 segment_shared_ptr_t
 lsmtree_segment_storage_t::get(const name_type_t &name) const {
   assert(!name.empty());
+
+  std::lock_guard lg(m_mutex);
+  if (auto it = m_segmentsMap.find(name); it != m_segmentsMap.end()) {
+    return it->second;
+  }
+
   return nullptr;
 }
 
-void lsmtree_segment_storage_t::put(segment_shared_ptr_t pLsmTreeSegment) {
-  assert(pLsmTreeSegment);
+void lsmtree_segment_storage_t::put(segment_shared_ptr_t pSegment) {
+  assert(pSegment);
+
+  std::lock_guard lg(m_mutex);
+  if (auto it = m_segmentsMap.find(pSegment->get_name());
+      it == m_segmentsMap.end()) {
+    m_segmentsMap.emplace(pSegment->get_name(), pSegment);
+    m_segmentsVector.emplace_back(pSegment);
+  }
 }
 
 void lsmtree_segment_storage_t::remove(const name_type_t &name) {
   assert(!name.empty());
+
+  std::lock_guard lg(m_mutex);
+  if (auto it = m_segmentsMap.find(name); it == m_segmentsMap.end()) {
+    m_segmentsMap.erase(name);
+    std::erase_if(m_segmentsVector, [&name](auto pSegment) {
+      return pSegment->get_name() == name;
+    });
+  }
 }
 
-} // namespace structures::lsmtree
+} // namespace structures::lsmtree::segment_storage

--- a/lib/structures/lsmtree/segments/lsmtree_segment_storage.h
+++ b/lib/structures/lsmtree/segments/lsmtree_segment_storage.h
@@ -5,6 +5,7 @@
 #include <unordered_map>
 
 #include <structures/lsmtree/segments/interface_lsmtree_segment.h>
+#include <structures/sorted_vector/sorted_vector.h>
 
 namespace structures::lsmtree::segment_storage {
 
@@ -30,7 +31,11 @@ public:
 private:
   mutable std::mutex m_mutex;
   segment_name_sptr_map m_segmentsMap;
-  segment_sptr_vector m_segmentsVector;
+  // segment_sptr_vector m_segmentsVector;
+  structures::sorted_vector::sorted_vector_t<
+      segment_shared_ptr_t,
+      std::function<bool(segment_shared_ptr_t, segment_shared_ptr_t)>>
+      m_segmentsVector;
 };
 
 using sptr = std::shared_ptr<lsmtree_segment_storage_t>;

--- a/lib/structures/lsmtree/segments/lsmtree_segment_storage.h
+++ b/lib/structures/lsmtree/segments/lsmtree_segment_storage.h
@@ -1,27 +1,45 @@
 #ifndef LSM_TREE_SEGMENT_STORAGE
 #define LSM_TREE_SEGMENT_STORAGE
 
-#include <iostream>
-#include <optional>
-#include <string>
+#include <memory>
 #include <unordered_map>
 
 #include <structures/lsmtree/segments/interface_lsmtree_segment.h>
 
-namespace structures::lsmtree {
+namespace structures::lsmtree::segment_storage {
 
-class lsmtree_segment_storage_t {
+class lsmtree_segment_storage_t
+    : public std::enable_shared_from_this<lsmtree_segment_storage_t> {
 public:
-  using name_type_t = std::string;
+  using name_type_t = interface_lsmtree_segment_t::name_t;
+  using segment_sptr_vector = std::vector<segment_shared_ptr_t>;
+  using segment_name_sptr_map =
+      std::unordered_map<name_type_t, segment_shared_ptr_t>;
 
-  segment_shared_ptr_t get(const name_type_t &name) const;
-  void put(segment_shared_ptr_t pLsmTreeSegment);
+  using size_type = segment_sptr_vector::size_type;
+
+  [[nodiscard]] segment_shared_ptr_t get(const name_type_t &name) const;
+  void put(segment_shared_ptr_t pSegment);
   void remove(const name_type_t &name);
+  [[nodiscard]] size_type size() const { return m_segmentsVector.size(); }
+
+  // TODO(lnikon): Iterate in sorted order
+  [[nodiscard]] inline auto begin() { return m_segmentsVector.begin(); }
+  [[nodiscard]] inline auto end() { return m_segmentsVector.end(); }
 
 private:
-  std::unordered_map<name_type_t, segment_shared_ptr_t> m_segments;
+  mutable std::mutex m_mutex;
+  segment_name_sptr_map m_segmentsMap;
+  segment_sptr_vector m_segmentsVector;
 };
 
-} // namespace structures::lsmtree
+using sptr = std::shared_ptr<lsmtree_segment_storage_t>;
+
+template <typename... Args> sptr make_shared(Args... args) {
+  return std::make_shared<lsmtree_segment_storage_t>(
+      std::forward<Args>(args)...);
+}
+
+} // namespace structures::lsmtree::segment_storage
 
 #endif // LSM_TREE_SEGMENT_STORAGE

--- a/lib/structures/lsmtree/segments/segment_config.h
+++ b/lib/structures/lsmtree/segments/segment_config.h
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace structures::lsmtree::segments {
+
+struct segment_config_t {
+  const bool DefaultPrepopulateSegmentIndex{false};
+  bool PrepopulateSegmentIndex{DefaultPrepopulateSegmentIndex};
+};
+
+} // namespace structures::lsmtree::segments

--- a/lib/structures/memtable/memtable.h
+++ b/lib/structures/memtable/memtable.h
@@ -37,6 +37,8 @@ public:
     enum class record_value_type_t { integer_k = 0, double_k, string_k };
 
     struct key_t {
+			using storage_type_t = std::string;
+
       explicit key_t(std::string key);
 
       key_t(const key_t &other);
@@ -52,7 +54,7 @@ public:
 
       static void swap(key_t &lhs, key_t &rhs);
 
-      std::string m_key;
+      storage_type_t m_key;
     };
 
     struct value_t {

--- a/lib/structures/memtable/memtable.h
+++ b/lib/structures/memtable/memtable.h
@@ -11,14 +11,12 @@
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_TRACE
 #include <spdlog/spdlog.h>
 
-#include <algorithm>
 #include <mutex>
 #include <optional>
 #include <sstream>
 #include <string>
 #include <utility>
 #include <variant>
-#include <vector>
 
 #include "structures/sorted_vector/sorted_vector.h"
 
@@ -141,5 +139,13 @@ template <typename... Args> auto make_unique(Args... args) {
   return std::make_unique<memtable_t>(std::forward<args>...);
 }
 } // namespace structures::memtable
+
+template <>
+struct std::hash<structures::memtable::memtable_t::record_t::key_t> {
+  using S = structures::memtable::memtable_t::record_t::key_t;
+  std::size_t operator()(const S &s) const {
+    return std::hash<std::string>{}(s.m_key);
+  }
+};
 
 #endif // MEMTABLE_H

--- a/lib/structures/sorted_vector/sorted_vector.h
+++ b/lib/structures/sorted_vector/sorted_vector.h
@@ -35,6 +35,8 @@ public:
   const_iterator cbegin() const;
   const_iterator cend() const;
 
+  iterator erase(iterator begin, iterator end);
+
 private:
   std::vector<Data> m_data;
 };
@@ -91,6 +93,12 @@ template <typename Data, typename Comparator>
 typename sorted_vector_t<Data, Comparator>::const_iterator
 sorted_vector_t<Data, Comparator>::cend() const {
   m_data.cend();
+}
+
+template <typename Data, typename Comparator>
+typename sorted_vector_t<Data, Comparator>::iterator
+sorted_vector_t<Data, Comparator>::erase(iterator begin, iterator end) {
+  return m_data.erase(begin, end);
 }
 
 } // namespace structures::sorted_vector


### PR DESCRIPTION
Currently, segments_storage is hidden within segments_manager. During the lookup, when lsmtree can't find the key in memtable it should query on disk SST for the key. This can be done in two ways:

1. Implement an interface for segments_manager which will allow key lookups. Kinda violates S in SOLID.
2. Implement an interface for segments_manager which will return thread-safe segments_storage. Iterate over that storage in sorted order(latest segments comes first) and lookup for a key.

segment type should support lookup of the keys. Each segment should store an index(dense or sparse, should be configurable) for datablocks within SST. On each lookup the index should be queried for the key, which will give an offset into the segment. After compactation is done, the old SSTs and their respective segments should be discarded.

Optionally, segments can act as a in-memory hot-caches for the SST.

segments_storage should provide interface to access segment via its identifier, interface to iterate over the segments in sorted order. The order of the segments is determined by their creation date. Latest comes first. Freshness of the segments can be determined through lstat.
