### PR TITLE
Remove redundant code & refactor memtable APIs

### DIFF
--- a/lib/db/wal/wal.cpp
+++ b/lib/db/wal/wal.cpp
@@ -4,7 +4,7 @@
 #include <string>
 #include <algorithm>
 #include <cctype>
-#include <locale>
+
 
 namespace db::wal
 {
@@ -24,12 +24,12 @@ auto wal_t::open() -> bool
     return m_log.open(m_path);
 }
 
-auto wal_t::path() -> fs::path_t
+auto wal_t::path() const -> fs::path_t
 {
     return m_path;
 }
 
-void wal_t::add(record_t rec) noexcept
+void wal_t::add(const record_t& rec) noexcept
 {
     m_records.push_back(rec);
 
@@ -53,9 +53,9 @@ void wal_t::reset()
 }
 
 // trim from start (in place)
-inline void ltrim(std::string &s)
+inline void ltrim(std::string &str)
 {
-    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char ch) { return !std::isspace(ch); }));
+    str.erase(str.begin(), std::find_if(str.begin(), str.end(), [](unsigned char ch) { return !std::isspace(ch); }));
 }
 
 // trim from end (in place)
@@ -73,7 +73,7 @@ inline auto trim(std::string &s) -> std::string &
 
 auto wal_t::recover() noexcept -> bool
 {
-    auto recordToString = [](const record_t &rec) -> std::string
+    auto recordToString = [](const record_t &rec)
     {
         std::stringstream strStream;
         rec.write(strStream);
@@ -82,7 +82,6 @@ auto wal_t::recover() noexcept -> bool
 
     spdlog::info("WAL recovery started");
     auto stringStream = m_log.stream();
-    std::int32_t record_type_int{0};
     std::string line;
     while (std::getline(stringStream, line))
     {
@@ -103,7 +102,7 @@ auto wal_t::recover() noexcept -> bool
     return true;
 }
 
-auto wal_t::records() noexcept -> std::vector<record_t>
+auto wal_t::records() const noexcept -> std::vector<record_t>
 {
     return m_records;
 }

--- a/lib/db/wal/wal.h
+++ b/lib/db/wal/wal.h
@@ -22,7 +22,7 @@ class wal_t
   public:
     using kv_t = structures::memtable::memtable_t::record_t;
 
-    enum operation_k : int8_t
+    enum class operation_k : int8_t
     {
         undefined_k = -1,
         add_k,
@@ -31,7 +31,7 @@ class wal_t
 
     struct record_t
     {
-        operation_k op{undefined_k};
+        operation_k op{operation_k::undefined_k};
         kv_t kv;
 
         template <typename Stream> void write(Stream &stream) const
@@ -70,14 +70,14 @@ class wal_t
      *
      * @return fs::path_t
      */
-    auto path() -> fs::path_t;
+    auto path() const -> fs::path_t;
 
     /**
      * @brief
      *
      * @param rec
      */
-    void add(record_t rec) noexcept;
+    void add(const record_t& rec) noexcept;
 
     /**
      * @brief
@@ -98,7 +98,7 @@ class wal_t
      *
      * @return std::vector<record_t>
      */
-    auto records() noexcept -> std::vector<record_t>;
+    auto records() const noexcept -> std::vector<record_t>;
 
   private:
     fs::path_t m_path;
@@ -108,7 +108,7 @@ class wal_t
 
 using shared_ptr_t = std::shared_ptr<wal_t>;
 
-template <typename... Args> auto make_shared(Args... args)
+template <typename... Args> auto make_shared(Args&&... args)
 {
     return std::make_shared<wal_t>(std::forward<Args>(args)...);
 }

--- a/lib/fs/append_only_file.h
+++ b/lib/fs/append_only_file.h
@@ -14,7 +14,7 @@ struct append_only_file_t
     using data_t = std::string;
 
     explicit append_only_file_t(fs::path_t path);
-    append_only_file_t() = delete;
+    append_only_file_t() = default;
     ~append_only_file_t() noexcept;
 
     auto open() noexcept -> bool;

--- a/lib/fs/random_access_file.h
+++ b/lib/fs/random_access_file.h
@@ -14,10 +14,6 @@ class random_access_file
 {
     class random_access_file_t
     {
-      public:
-        void write();
-
-      private:
     };
 };
 

--- a/lib/structures/lsmtree/segments/lsmtree_regular_segment.cpp
+++ b/lib/structures/lsmtree/segments/lsmtree_regular_segment.cpp
@@ -47,9 +47,9 @@ std::optional<record_t> regular_segment_t::record(const hashindex::hashindex_t::
 
 void regular_segment_t::flush()
 {
-    random_access_file_t
-        // Skip execution if for some reason the memtable is empty
-        if (m_memtable.has_value() && m_memtable->empty())
+    // random_access_file_t
+    // Skip execution if for some reason the memtable is empty
+    if (m_memtable.has_value() && m_memtable->empty())
     {
         spdlog::warn("Can not flush empty memtable at segment {}", m_path.c_str());
         return;

--- a/lib/structures/memtable/memtable.h
+++ b/lib/structures/memtable/memtable.h
@@ -49,7 +49,7 @@ class memtable_t
 
             [[nodiscard]] auto size() const -> std::size_t;
 
-            static void swap(key_t &lhs, key_t &rhs);
+            static void swap(key_t &lhs, key_t &rhs) noexcept;
 
             storage_type_t m_key;
         };
@@ -148,7 +148,7 @@ class memtable_t
      *
      * @param record
      */
-    void emplace(const record_t &record);
+    void emplace(record_t record);
 
     /**
      * @brief
@@ -171,13 +171,6 @@ class memtable_t
      * @brief
      */
     [[nodiscard]] auto empty() const -> bool;
-
-    /**
-     * @brief
-     *
-     * @param pMemtable
-     */
-    void merge(memtable_t pMemtable) noexcept;
 
     /**
      * @brief
@@ -216,13 +209,6 @@ class memtable_t
     template <typename stream_gt> void read(stream_gt &outStream);
 
   private:
-    /**
-     * @brief
-     *
-     * @param record
-     */
-    void update_size(const record_t &record);
-
     storage_t m_data;
     std::size_t m_size{0};
     std::size_t m_count{0};

--- a/lib/structures/skiplist/skiplist.h
+++ b/lib/structures/skiplist/skiplist.h
@@ -142,7 +142,7 @@ template <typename record_gt, typename comparator_gt> class skiplist_t
         return std::nullopt;
     }
 
-    void emplace(const record_gt &record)
+    void emplace(record_gt&& record)
     {
         const auto newLevel{random_level()};
         if (newLevel > m_level)
@@ -167,7 +167,7 @@ template <typename record_gt, typename comparator_gt> class skiplist_t
         if (current == nullptr || current->record.m_key != record.m_key)
         {
             // Insert new node
-            node_shared_ptr_t newNode = std::make_shared<node_t>(record, m_level);
+            node_shared_ptr_t newNode = std::make_shared<node_t>(std::forward<record_gt>(record), m_level);
             for (std::int64_t i{0}; i <= newLevel; i++)
             {
                 newNode->forward[i] = to_be_updated[i]->forward[i];
@@ -179,7 +179,7 @@ template <typename record_gt, typename comparator_gt> class skiplist_t
         else if (current->record.m_key == record.m_key)
         {
             // Update value of the existing node
-            current->record = record;
+            current->record = std::forward<record_gt>(record);
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced performance of the `emplace` method in the `skiplist_t` class by optimizing record handling with move semantics.
	- Allowed flexible instantiation of `append_only_file_t` without requiring a specific path argument.

- **Bug Fixes**
	- Removed the `write()` method from the `random_access_file_t` class, improving encapsulation and design.

- **Refactor**
	- Improved const-correctness and type safety in the `wal_t` class methods.
	- Streamlined the `memtable_t` class interface by removing unnecessary methods and optimizing existing ones.

- **Documentation**
	- Updated comments for clarity in the `lsmtree_regular_segment.cpp` file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->